### PR TITLE
remove the use of autobox

### DIFF
--- a/lib/Dist/Zilla/Plugin/Conflicts.pm
+++ b/lib/Dist/Zilla/Plugin/Conflicts.pm
@@ -8,7 +8,6 @@ use Dist::CheckConflicts 0.02 ();
 use Dist::Zilla 4.0 ();
 use Dist::Zilla::File::InMemory;
 use Dist::Zilla::File::FromCode;
-use Moose::Autobox 0.09;
 
 use Moose;
 
@@ -230,7 +229,7 @@ sub setup_installer {
     my $self = shift;
 
     my $found_installer;
-    for my $file ( $self->zilla()->files()->flatten() ) {
+    for my $file (@{ $self->zilla()->files() }) {
         if ( $file->name() =~ /Makefile\.PL$/ ) {
             $self->_munge_makefile_pl($file);
             $found_installer++;


### PR DESCRIPTION
...as has been done for Dist-Zilla itself and in progress in various plugins (and also, autobox.pm doesn't install on 5.21.7)
