### PR TITLE
Remove the DONATION section

### DIFF
--- a/lib/Dist/Zilla/Plugin/Conflicts.pm
+++ b/lib/Dist/Zilla/Plugin/Conflicts.pm
@@ -458,21 +458,4 @@ C<bug-dist-zilla-plugin-conflicts@rt.cpan.org>, or through the web interface
 at L<http://rt.cpan.org>. I will be notified, and then you'll automatically be
 notified of progress on your bug as I make changes.
 
-=head1 DONATIONS
-
-If you'd like to thank me for the work I've done on this module, please
-consider making a "donation" to me via PayPal. I spend a lot of free time
-creating free software, and would appreciate any support you'd care to offer.
-
-Please note that B<I am not suggesting that you must do this> in order for me
-to continue working on this particular software. I will continue to do so,
-inasmuch as I have in the past, for as long as it interests me.
-
-Similarly, a donation made in this way will probably not make me work on this
-software much more, unless I get so many donations that I can consider working
-on free software full time, which seems unlikely at best.
-
-To donate, log into PayPal and send money to autarch@urth.org or use the
-button on this page: L<http://www.urth.org/~autarch/fs-donation.html>
-
 =cut


### PR DESCRIPTION
This section is added automatically by Pod/Weaver::PluginBundle::DROLSKY, so it appears twice in the generated POD.