### PR TITLE
Fix conflict with Dist::Zilla::Plugin::PodCoverageTests

### DIFF
--- a/lib/Dist/Zilla/Plugin/Conflicts.pm
+++ b/lib/Dist/Zilla/Plugin/Conflicts.pm
@@ -127,7 +127,11 @@ package # hide from PAUSE
 use strict;
 use warnings;
 
-# this module was generated with {{ ref($plugin) . ' ' . ($plugin->VERSION || '<self>') }}
+=for *EVERYTHING*
+
+this module was generated with {{ ref($plugin) . ' ' . ($plugin->VERSION || '<self>') }}
+
+=cut
 
 use Dist::CheckConflicts
     -dist      => '{{ $dist_name }}',


### PR DESCRIPTION
This module was causing the PodCoverageTests to fail as it was being detected and did not have any pod. To fix this I've made the existing comment into a Pod exception for the file.